### PR TITLE
Simplify `useModules` logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,14 @@ export const registerModules = (modulesToRegister: Module[]) => {
 
 export const resetModules = () => modules.splice(0, modules.length)
 
-export const useModules = (moduleNames: string[]): Record<string, Module> => {
-  moduleNames.forEach(moduleName => {
-    if (!modules.some(registeredModule => registeredModule.name === moduleName)) {
+export const useModules = (moduleNames: string[]): Record<string, Module> => Object.fromEntries(
+  moduleNames.map(moduleName => {
+    const module = modules.find(registeredModule => registeredModule.name === moduleName)
+    
+    if (!module) {
       throw new Error(`vue-modulize: module "${moduleName}" is not registered`)
     }
-  })
-
-  return modules
-    .filter(registeredModule => moduleNames.some(moduleName => moduleName === registeredModule.name))
-    .reduce((previous, current) => ({ ...previous, [current.name]: current }), {})
-}
+    
+    return [moduleName, module]
+  }),
+)


### PR DESCRIPTION
* Avoid multiple `modules.some` calls per requested module.
* Avoid hard to read and unnecessarily `O(n²)` `reduce`